### PR TITLE
fix: changelog history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 * Add barrierColor property to custom bottom sheet implementation ([66abb01](https://github.com/Stacked-Org/services/commit/66abb0172f6bb5b42e62fbb0ebe3e6709f1bb542))
 
-## 1.0.0
+## 0.9.10
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Provides some essential services to aid in implementing the Stacked architecture. These services are only here to reduce boilerplate code for the users of the Stacked Architecture that uses the architecture as instructed by FilledStacks on the architecture series.
 
+## Git Conventional Commits
+
+Since version `1.0.1` we will try to stick with **Conventional Commits** specification.
+
 ## Migration from 0.5.x -> 0.6.x
 
 - The custom builder function has changed for the `DialogService` instead of using `registerCustomDialogBuilder` you should now create a map of builders and pass it to `registerCustomDialogBuilders`.


### PR DESCRIPTION
On the migration to Stacked-Org, the version history got broken. In an attempt to solve this situation we do the following:

- Update CHANGELOG manually to replace 1.0.0 with 0.9.10 which was lost
- Assign manually tag `1.0.0` to the same commit of tag `0.10.0`
- Refer on README we are going to use Conventional Commits henceforth