### PR TITLE
fix RouterService clearStackAndShow

### DIFF
--- a/lib/src/navigation/router_service.dart
+++ b/lib/src/navigation/router_service.dart
@@ -51,7 +51,8 @@ class RouterService {
 
   Future<void> clearStackAndShow(PageRouteInfo route,
       {OnNavigationFailure? onFailure}) {
-    return router.pushAll([route], onFailure: onFailure);
+    router.clear();
+    return router.navigate(route, onFailure: onFailure);
   }
 
   Future<void> clearStackAndShowView(


### PR DESCRIPTION
This PR fixes `clearStackAndShow` method in `RouterService` which currently pushes the route on top without clearing the current stack