### PR TITLE
fix: use push instead of navigate on router service

### DIFF
--- a/lib/src/dialog/dialog_service.dart
+++ b/lib/src/dialog/dialog_service.dart
@@ -184,8 +184,9 @@ class DialogService {
     Color barrierColor = Colors.black54,
     bool barrierDismissible = false,
     String barrierLabel = '',
-    @Deprecated('Prefer to use `data` and pass in a generic type. customData doesn\'t work anymore')
-        dynamic customData,
+    @Deprecated(
+        'Prefer to use `data` and pass in a generic type. customData doesn\'t work anymore')
+    dynamic customData,
     R? data,
   }) {
     assert(

--- a/lib/src/dialog/dialog_service.dart
+++ b/lib/src/dialog/dialog_service.dart
@@ -125,7 +125,7 @@ class DialogService {
               key: Key('dialog_touchable_cancel'),
               textChildKey: Key('dialog_text_cancelButtonText'),
               dialogPlatform: dialogPlatform,
-              text: cancelTitle!,
+              text: cancelTitle,
               cancelBtnColor: cancelTitleColor,
               isCancelButton: true,
               onPressed: () {

--- a/lib/src/models/overlay_request.dart
+++ b/lib/src/models/overlay_request.dart
@@ -55,7 +55,7 @@ class OverlayRequest<T> {
     this.additionalButtonTitle,
     this.takesInput,
     @Deprecated('Prefer to use `data` and pass in a generic type.')
-        this.customData,
+    this.customData,
     this.data,
     this.variant,
   });
@@ -75,7 +75,7 @@ class DialogRequest<T> extends OverlayRequest<T> {
     String? additionalButtonTitle,
     bool? takesInput,
     @Deprecated('Prefer to use `data` and pass in a generic type.')
-        dynamic customData,
+    dynamic customData,
     T? data,
     dynamic variant,
   }) : super(
@@ -109,7 +109,7 @@ class SheetRequest<T> extends OverlayRequest<T> {
     String? additionalButtonTitle,
     bool? takesInput,
     @Deprecated('Prefer to use `data` and pass in a generic type.')
-        dynamic customData,
+    dynamic customData,
     T? data,
     dynamic variant,
   }) : super(

--- a/lib/src/models/overlay_response.dart
+++ b/lib/src/models/overlay_response.dart
@@ -14,7 +14,7 @@ class OverlayResponse<T> {
   OverlayResponse({
     this.confirmed = false,
     @Deprecated('Prefer to use `data` and pass in a generic type.')
-        this.responseData,
+    this.responseData,
     this.data,
   });
 }
@@ -23,8 +23,9 @@ class OverlayResponse<T> {
 class DialogResponse<T> extends OverlayResponse<T> {
   DialogResponse({
     bool confirmed = false,
-    @Deprecated('Prefer to use `data` and pass in a generic type. ResponseData has no effect anymore')
-        dynamic responseData,
+    @Deprecated(
+        'Prefer to use `data` and pass in a generic type. ResponseData has no effect anymore')
+    dynamic responseData,
     T? data,
   }) : super(
           confirmed: confirmed,
@@ -47,8 +48,9 @@ class DialogResponse<T> extends OverlayResponse<T> {
 class SheetResponse<T> extends OverlayResponse<T> {
   SheetResponse({
     bool confirmed = false,
-    @Deprecated('Prefer to use `data` and pass in a generic type.  ResponseData has no effect anymore')
-        dynamic responseData,
+    @Deprecated(
+        'Prefer to use `data` and pass in a generic type.  ResponseData has no effect anymore')
+    dynamic responseData,
     T? data,
   }) : super(
           confirmed: confirmed,

--- a/lib/src/navigation/navigation_service.dart
+++ b/lib/src/navigation/navigation_service.dart
@@ -59,8 +59,9 @@ class NavigationService {
     Duration? defaultDurationTransition,
     bool? defaultGlobalState,
     Transition? defaultTransitionStyle,
-    @Deprecated('Prefer to use the defaultTransitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-        String? defaultTransition,
+    @Deprecated(
+        'Prefer to use the defaultTransitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
+    String? defaultTransition,
   }) {
     G.Get.config(
         enableLog: enableLog,
@@ -90,16 +91,18 @@ class NavigationService {
   Future<T?>? navigateWithTransition<T>(
     Widget page, {
     bool? opaque,
-    @Deprecated('Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-        String transition = '',
+    @Deprecated(
+        'Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
+    String transition = '',
     Duration? duration,
     bool? popGesture,
     int? id,
     Curve? curve,
     bool fullscreenDialog = false,
     bool preventDuplicates = true,
-    @Deprecated('Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-        Transition? transitionClass,
+    @Deprecated(
+        'Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
+    Transition? transitionClass,
     Transition? transitionStyle,
     String? routeName,
   }) {
@@ -137,16 +140,18 @@ class NavigationService {
   Future<T?>? replaceWithTransition<T>(
     Widget page, {
     bool? opaque,
-    @Deprecated('Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-        String transition = '',
+    @Deprecated(
+        'Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
+    String transition = '',
     Duration? duration,
     bool? popGesture,
     int? id,
     Curve? curve,
     bool fullscreenDialog = false,
     bool preventDuplicates = true,
-    @Deprecated('Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-        Transition? transitionClass,
+    @Deprecated(
+        'Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
+    Transition? transitionClass,
     Transition? transitionStyle,
     String? routeName,
   }) {
@@ -234,8 +239,9 @@ class NavigationService {
     bool fullscreenDialog = false,
     bool? popGesture,
     bool preventDuplicates = true,
-    @Deprecated('Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-        Transition? transition,
+    @Deprecated(
+        'Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
+    Transition? transition,
     Transition? transitionStyle,
   }) {
     return G.Get.to<T?>(

--- a/lib/src/navigation/router_service.dart
+++ b/lib/src/navigation/router_service.dart
@@ -17,14 +17,14 @@ class RouterService {
     PageRouteInfo route, {
     OnNavigationFailure? onFailure,
   }) =>
-      router.navigate(route, onFailure: onFailure);
+      router.push(route, onFailure: onFailure);
 
   Future<void> navigateToPath({
     required String path,
     bool includePrefixMatches = false,
     OnNavigationFailure? onFailure,
   }) =>
-      router.navigateNamed(
+      router.pushNamed(
         path,
         includePrefixMatches: includePrefixMatches,
         onFailure: onFailure,

--- a/lib/src/snackbar/snackbar_service.dart
+++ b/lib/src/snackbar/snackbar_service.dart
@@ -161,7 +161,7 @@ class SnackbarService {
     final hasMainButtonBuilder = mainButtonBuilder != null;
 
     final mainButtonWidget = hasMainButtonBuilder
-        ? mainButtonBuilder!(mainButtonTitle, onMainButtonTapped)
+        ? mainButtonBuilder(mainButtonTitle, onMainButtonTapped)
         : _getMainButtonWidget(
             mainButtonTitle: mainButtonTitle,
             mainButtonStyle: snackbarConfig.mainButtonStyle ?? mainButtonStyle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.2
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_services
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Instead of using `navigate` and `navigateNamed` which do not support await, we replace them with `push` and `pushNamed` respectively.

Closes https://github.com/Stacked-Org/stacked/issues/930