### PR TITLE
feat: auto close Snackbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,28 @@ _snackbarService.showCustomSnackBar(
 
 The snackbar service does not cover every scenario at the moment, especially for adding multiple actions or using icons. If you're looking for those kind of features please make an issue or make a PR for the functionality. I would greatly appreciate it.
 
+### Auto close snackbar when tapped main button
+
+To achieve the same behavior just like Flutter's snackbar where the snackbar will close when tapped the action button in the snackbar, you can set `closeSnackbarOnMainButtonTapped` to `true` in the `SnackbarConfig`.
+
+```dart
+service.registerSnackbarConfig(
+  SnackbarConfig(
+    closeSnackbarOnMainButtonTapped: true,
+  ),
+);
+```
+```dart
+service.registerCustomSnackbarConfig(
+  variant: SnackbarType.autoCloseMainButtonTapped,
+  config: SnackbarConfig(
+    snackPosition: SnackPosition.TOP,
+    closeSnackbarOnMainButtonTapped: true,
+    borderRadius: 1,
+  ),
+);
+```
+
 ## BottomSheet Service
 
 This service, similar to the others above, allows the user to show a `BottomSheet` from the same place they handle their business logic. It's calls that can be awaited on for a result returned by the user. This makes writing your business logic much easier in the long run.

--- a/example/lib/enums/snackbar_type.dart
+++ b/example/lib/enums/snackbar_type.dart
@@ -1,2 +1,6 @@
 /// The type of snackbar to show
-enum SnackbarType { blueAndYellow, greenAndRed }
+enum SnackbarType {
+  blueAndYellow,
+  greenAndRed,
+  autoCloseMainButtonTapped,
+}

--- a/example/lib/ui/setup_snackbar_ui.dart
+++ b/example/lib/ui/setup_snackbar_ui.dart
@@ -35,4 +35,34 @@ void setupSnackbarUi() {
       borderRadius: 1,
     ),
   );
+
+  service.registerCustomSnackbarConfig(
+    variant: SnackbarType.autoCloseMainButtonTapped,
+    config: SnackbarConfig(
+      snackPosition: SnackPosition.TOP,
+      closeSnackbarOnMainButtonTapped: true,
+      borderRadius: 1,
+    ),
+  );
+
+  service.registerCustomMainButtonBuilder(
+    variant: SnackbarType.autoCloseMainButtonTapped,
+    builder: (title, onTap) => TextButton(
+      child: Text(
+        title ?? 'Undo',
+      ),
+      onPressed: () {
+        if (onTap != null) {
+          onTap();
+        }
+      },
+      style: TextButton.styleFrom(
+        foregroundColor: Colors.white,
+        textStyle: TextStyle(
+          fontSize: 15,
+          decoration: TextDecoration.underline,
+        ),
+      ),
+    ),
+  );
 }

--- a/example/lib/ui/views/snackbar_view.dart
+++ b/example/lib/ui/views/snackbar_view.dart
@@ -88,6 +88,32 @@ class SnackbarView extends StatelessWidget {
               'Show Green and Red Snackbar',
             ),
           ),
+          Text(
+            'Press the button below and press the \'Undo\' button to auto close the snackbar when main button tapped',
+            softWrap: true,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 14,
+            ),
+          ),
+          OutlinedButton(
+            onPressed: () async {
+              _snackbarService.showCustomSnackBar(
+                variant: SnackbarType.autoCloseMainButtonTapped,
+                message:
+                    'Snackbar auto close when tapped Undo',
+                duration: Duration(seconds: 5),
+                onTap: (_) {
+                  print('snackbar tapped');
+                },
+                mainButtonTitle: 'Undo',
+                onMainButtonTapped: () => print('Undo the action and closing the snackbar'),
+              );
+            },
+            child: Text(
+              'Show auto close snackbar',
+            ),
+          ),
         ],
       ),
     );

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,15 +23,19 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.4
-  stacked: 
+  stacked:
   stacked_shared:
-  stacked_services: 
+  stacked_services:
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   stacked_generator: ^0.6.5
   build_runner: ^2.1.11
+
+dependency_overrides:
+  stacked_services:
+    path: ../
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/src/snackbar/snackbar_config.dart
+++ b/lib/src/snackbar/snackbar_config.dart
@@ -38,6 +38,9 @@ class SnackbarConfig {
   /// Sets the color of the main button text regardless of [textColor]
   Color? mainButtonTextColor;
 
+  /// Auto close the snackbar when main button tapped
+  bool closeSnackbarOnMainButtonTapped;
+
   ButtonStyle? mainButtonStyle;
   List<BoxShadow>? boxShadows;
   Gradient? backgroundGradient;
@@ -69,6 +72,7 @@ class SnackbarConfig {
     this.messageColor,
     this.messageTextStyle,
     this.mainButtonTextColor,
+    this.closeSnackbarOnMainButtonTapped = false,
     this.mainButtonStyle,
     this.instantInit = false,
     this.shouldIconPulse = true,

--- a/lib/src/snackbar/snackbar_service.dart
+++ b/lib/src/snackbar/snackbar_service.dart
@@ -161,7 +161,13 @@ class SnackbarService {
     final hasMainButtonBuilder = mainButtonBuilder != null;
 
     final mainButtonWidget = hasMainButtonBuilder
-        ? mainButtonBuilder(mainButtonTitle, onMainButtonTapped)
+        ? mainButtonBuilder(
+            mainButtonTitle,
+            () => _handleOnMainButtonTapped(
+              onMainButtonTapped,
+              snackbarConfig.closeSnackbarOnMainButtonTapped,
+            ),
+          )
         : _getMainButtonWidget(
             mainButtonTitle: mainButtonTitle,
             mainButtonStyle: snackbarConfig.mainButtonStyle ?? mainButtonStyle,
@@ -274,7 +280,22 @@ class SnackbarService {
               config?.mainButtonTextColor ?? config?.textColor ?? Colors.white,
         ),
       ),
-      onPressed: onMainButtonTapped,
+      onPressed: () => _handleOnMainButtonTapped(
+        onMainButtonTapped,
+        config?.closeSnackbarOnMainButtonTapped ?? false,
+      ),
     );
+  }
+
+  void _handleOnMainButtonTapped(
+    void Function()? onMainButtonTapped,
+    bool closeSnackbarOnMainButtonTapped,
+  ) {
+    if (onMainButtonTapped != null) {
+      onMainButtonTapped();
+      if (closeSnackbarOnMainButtonTapped) {
+        closeSnackbar();
+      }
+    }
   }
 }


### PR DESCRIPTION
This long overdue PR is related to this [issue](https://github.com/Stacked-Org/stacked/issues/639). 😅

I tackle this issue by make it optional to auto-close the snack bar when tapped the main button. Setting in the `snackbarConfig` is required to make it happen. 

Please review and comment if there's any improvement needed. Thank you! 