### PR TITLE
bottomsheet elevation not user adjustable

### DIFF
--- a/lib/src/bottom_sheet/bottom_sheet_service.dart
+++ b/lib/src/bottom_sheet/bottom_sheet_service.dart
@@ -35,6 +35,7 @@ class BottomSheetService {
     Duration? enterBottomSheetDuration,
     bool? ignoreSafeArea,
     bool useRootNavigator = false,
+    double elevation = 1,
   }) {
     return Get.bottomSheet<SheetResponse?>(
       Material(
@@ -51,6 +52,7 @@ class BottomSheetService {
       backgroundColor: Theme.of(Get.context!).brightness == Brightness.light
           ? Colors.white
           : Colors.grey[800],
+      elevation: elevation,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.only(
           topLeft: Radius.circular(15),
@@ -98,6 +100,7 @@ class BottomSheetService {
     String? additionalButtonTitle,
     bool takesInput = false,
     Color barrierColor = Colors.black54,
+    double elevation = 1,
     bool barrierDismissible = true,
     bool isScrollControlled = false,
     String barrierLabel = '',
@@ -149,6 +152,7 @@ class BottomSheetService {
         ),
       ),
       barrierColor: barrierColor,
+      elevation: elevation,
       isDismissible: barrierDismissible,
       isScrollControlled: isScrollControlled,
       enableDrag: barrierDismissible && enableDrag,


### PR DESCRIPTION
bottom sheet has a ghost background colour that shows up when not covered by a painted widget. the ghost background colour was the default elevation from the Getx package, this pr gives the user the privilege to adjust the elevation.

to test:
1. create a custombottomsheet using the cli command: stacked create bottom_sheet [anyname]
2. make your bottomsheet a column widget or any widget with a transparent background
3. follow these [steps](https://www.filledstacks.com/post/bottom-sheets-in-flutter-through-stacked-services/) to use the bottom sheet.
3.1. If the page it outdated; create a view/widget using the CLI, from the View's view_model, assign the bottom sheet service e.g. final _bottomSheetService = locator<BottomSheetService>(). 
3.2. use a function to use the bottom sheet e.g. void bottomSheet() async { _bottomSheetService.showCustomSheet(variant: BottomSheetType.[bottomsheename], elevation: 0) } --note: remove elevation to see how it looked before
4. inside your view, have a button that calls your bottomsheet function