### PR TITLE
feat: mutate bottom sheet and dialog builders

### DIFF
--- a/lib/src/bottom_sheet/bottom_sheet_service.dart
+++ b/lib/src/bottom_sheet/bottom_sheet_service.dart
@@ -20,7 +20,7 @@ class BottomSheetService {
   Map<dynamic, SheetBuilder>? _sheetBuilders;
 
   void setCustomSheetBuilders(Map<dynamic, SheetBuilder> builders) {
-    _sheetBuilders = builders;
+    _sheetBuilders = {...?_sheetBuilders, ...builders};
   }
 
   Future<SheetResponse?> showBottomSheet({

--- a/lib/src/dialog/dialog_service.dart
+++ b/lib/src/dialog/dialog_service.dart
@@ -23,7 +23,7 @@ class DialogService {
   Map<dynamic, DialogBuilder>? _dialogBuilders;
 
   void registerCustomDialogBuilders(Map<dynamic, DialogBuilder> builders) {
-    _dialogBuilders = builders;
+    _dialogBuilders = {...?_dialogBuilders, ...builders};
   }
 
   Map<dynamic, DialogBuilder> _customDialogBuilders =


### PR DESCRIPTION
### Summary

This PR allows mutation of `_sheetBuilders` and `_dialogBuilders` allowing to call `setCustomSheetBuilders` and `registerCustomDialogBuilders` again.

### Use case
This is useful when you have a shared bottom sheets and dialogs in different projects in a monorepo. I have a common package that is being used in two different apps.

### Code example for the usage
```dart
  static Future<void> initializeDependencies() async {
    await setupLocator();
    common.setupBottomSheetUi();
    setupBottomSheetUi();
    common.setupDialogUi();
    setupDialogUi();
  }
```