### PR TITLE
Feature Request: Add routeSettings, transitionBuilder and navigatorKey Parameters to Dialog Methods

### DIFF
--- a/example/lib/ui/views/dialog_view.dart
+++ b/example/lib/ui/views/dialog_view.dart
@@ -1,9 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:stacked_services/stacked_services.dart';
 import 'package:stacked_services_example/ui/setup_dialog_ui.dart';
 
 import '../../app/app.locator.dart';
-import 'package:flutter/material.dart';
-import 'package:stacked_services/stacked_services.dart';
-
 import '../../enums/dialog_type.dart';
 
 class DialogView extends StatelessWidget {
@@ -31,6 +30,7 @@ class DialogView extends StatelessWidget {
                   await _dialogService.showDialog(
                     title: 'Test Dialog Title',
                     description: 'Test Dialog Description',
+                    //routeSettings: RouteSettings(name: '/materialDialog'),
                   );
                 },
                 child: Text(
@@ -50,9 +50,10 @@ class DialogView extends StatelessWidget {
               OutlinedButton(
                 onPressed: () async {
                   await _dialogService.showDialog(
-                    title: 'Test Dialog Title',
-                    // description: 'Test Dialog Description',
-                  );
+                      title: 'Test Dialog Title',
+                      // description: 'Test Dialog Description',
+                      routeSettings: RouteSettings(name: '/materialDialog'),
+                      navigatorKey: StackedService.navigatorKey);
                 },
                 child: Text(
                   'Show Material Dialog',
@@ -73,6 +74,7 @@ class DialogView extends StatelessWidget {
                   await _dialogService.showDialog(
                     // title: 'Test Dialog Title',
                     description: 'Test Dialog Description',
+                    routeSettings: RouteSettings(name: '/materialDialog'),
                   );
                 },
                 child: Text(
@@ -89,13 +91,23 @@ class DialogView extends StatelessWidget {
               OutlinedButton(
                 onPressed: () async {
                   await _dialogService.showCustomDialog(
-                      variant: DialogType.Basic,
-                      title: 'This is a custom UI with Text as main button',
-                      description:
-                          'Sheck out the builder in the dialog_ui_register.dart file',
-                      mainButtonTitle: 'Ok',
-                      showIconInMainButton: false,
-                      barrierDismissible: true);
+                    variant: DialogType.Basic,
+                    title: 'This is a custom UI with Text as main button',
+                    description: 'Sheck out the builder in the dialog_ui_register.dart file',
+                    mainButtonTitle: 'Ok',
+                    showIconInMainButton: false,
+                    barrierDismissible: true,
+                    routeSettings: RouteSettings(name: '/customDialogWithTransition'),
+                    transitionBuilder: (context, animation, secondaryAnimation, child) => SlideTransition(
+                      position: animation.drive(
+                        Tween<Offset>(
+                          begin: const Offset(1.0, 0.0),
+                          end: const Offset(0.0, 0.0),
+                        ),
+                      ),
+                      child: child,
+                    ),
+                  );
                 },
                 child: Text(
                   'Show Custom Text Dialog',
@@ -110,17 +122,15 @@ class DialogView extends StatelessWidget {
               ),
               OutlinedButton(
                 onPressed: () async {
-                  final response = await _dialogService.showCustomDialog<
-                      GenericDialogResponse, GenericDialogRequest>(
+                  final response = await _dialogService.showCustomDialog<GenericDialogResponse, GenericDialogRequest>(
                     variant: DialogType.Generic,
-                    title:
-                        'This is a custom Generic UI with Text as main button',
-                    description:
-                        'Sheck out the builder in the dialog_ui_register.dart file',
+                    title: 'This is a custom Generic UI with Text as main button',
+                    description: 'Sheck out the builder in the dialog_ui_register.dart file',
                     mainButtonTitle: 'Ok',
                     showIconInMainButton: false,
                     barrierDismissible: true,
                     data: GenericDialogRequest(),
+                    routeSettings: RouteSettings(name: '/customDialog'),
                   );
 
                   print(response?.data?.message ?? '');
@@ -134,9 +144,9 @@ class DialogView extends StatelessWidget {
                   await _dialogService.showCustomDialog(
                     variant: DialogType.Basic,
                     title: 'This is a custom UI with icon',
-                    description:
-                        'Sheck out the builder in the dialog_ui_register.dart file',
+                    description: 'Sheck out the builder in the dialog_ui_register.dart file',
                     showIconInMainButton: true,
+                    routeSettings: RouteSettings(name: '/customDialog'),
                   );
                 },
                 child: Text(
@@ -156,6 +166,7 @@ class DialogView extends StatelessWidget {
                     title: 'Test Confirmation Dialog Title',
                     description: 'Test Confirmation Dialog Description',
                     barrierDismissible: true,
+                    routeSettings: RouteSettings(name: '/materialConfirmationDialog'),
                   );
                 },
                 child: Text(
@@ -175,6 +186,7 @@ class DialogView extends StatelessWidget {
                     dialogPlatform: DialogPlatform.Cupertino,
                     title: 'Test Confirmation Dialog Title',
                     description: 'Test Dialog Description',
+                    routeSettings: RouteSettings(name: '/materialDialog'),
                   );
                 },
                 child: Text(
@@ -198,6 +210,7 @@ class DialogView extends StatelessWidget {
                     title: 'Test Confirmation Dialog Title',
                     description: 'Test Confirmation Dialog Description',
                     barrierDismissible: true,
+                    routeSettings: RouteSettings(name: '/materialConfirmationDialog'),
                   );
                 },
                 child: Text(

--- a/lib/src/dialog/dialog_service.dart
+++ b/lib/src/dialog/dialog_service.dart
@@ -26,11 +26,9 @@ class DialogService {
     _dialogBuilders = {...?_dialogBuilders, ...builders};
   }
 
-  Map<dynamic, DialogBuilder> _customDialogBuilders =
-      Map<dynamic, DialogBuilder>();
+  Map<dynamic, DialogBuilder> _customDialogBuilders = Map<dynamic, DialogBuilder>();
 
-  @Deprecated(
-      'Prefer to use the StackedServices.navigatorKey instead of using this key. This will be removed in the next major version update for stacked.')
+  @Deprecated('Prefer to use the StackedServices.navigatorKey instead of using this key. This will be removed in the next major version update for stacked.')
   get navigatorKey {
     return Get.key;
   }
@@ -47,9 +45,7 @@ class DialogService {
   )
   void registerCustomDialogBuilder({
     required dynamic variant,
-    required Widget Function(
-            BuildContext, DialogRequest, Function(DialogResponse))
-        builder,
+    required Widget Function(BuildContext, DialogRequest, Function(DialogResponse)) builder,
   }) {
     _customDialogBuilders[variant] = builder;
   }
@@ -68,6 +64,8 @@ class DialogService {
     String buttonTitle = 'Ok',
     Color? buttonTitleColor,
     bool barrierDismissible = false,
+    RouteSettings? routeSettings,
+    GlobalKey<NavigatorState>? navigatorKey,
 
     /// Indicates which [DialogPlatform] to show.
     ///
@@ -84,11 +82,11 @@ class DialogService {
         buttonTitleColor: buttonTitleColor,
         dialogPlatform: dialogPlatform,
         barrierDismissible: barrierDismissible,
+        routeSettings: routeSettings,
+        navigatorKey: navigatorKey,
       );
     } else {
-      var _dialogType = GetPlatform.isAndroid
-          ? DialogPlatform.Material
-          : DialogPlatform.Cupertino;
+      var _dialogType = GetPlatform.isAndroid ? DialogPlatform.Material : DialogPlatform.Cupertino;
       return _showDialog(
         title: title,
         description: description,
@@ -98,6 +96,8 @@ class DialogService {
         buttonTitleColor: buttonTitleColor,
         dialogPlatform: _dialogType,
         barrierDismissible: barrierDismissible,
+        routeSettings: routeSettings,
+        navigatorKey: navigatorKey,
       );
     }
   }
@@ -111,6 +111,8 @@ class DialogService {
     Color? buttonTitleColor,
     DialogPlatform dialogPlatform = DialogPlatform.Material,
     bool barrierDismissible = false,
+    RouteSettings? routeSettings,
+    GlobalKey<NavigatorState>? navigatorKey,
   }) {
     var isConfirmationDialog = cancelTitle != null;
     return Get.dialog<DialogResponse>(
@@ -153,6 +155,8 @@ class DialogService {
         ],
       ),
       barrierDismissible: barrierDismissible,
+      routeSettings: routeSettings,
+      navigatorKey: navigatorKey,
     );
   }
 
@@ -185,9 +189,10 @@ class DialogService {
     bool barrierDismissible = false,
     String barrierLabel = '',
     bool useSafeArea = true,
-    @Deprecated(
-        'Prefer to use `data` and pass in a generic type. customData doesn\'t work anymore')
-    dynamic customData,
+    RouteSettings? routeSettings,
+    GlobalKey<NavigatorState>? navigatorKey,
+    RouteTransitionsBuilder? transitionBuilder,
+    @Deprecated('Prefer to use `data` and pass in a generic type. customData doesn\'t work anymore') dynamic customData,
     R? data,
   }) {
     assert(
@@ -207,6 +212,9 @@ class DialogService {
       transitionDuration: const Duration(milliseconds: 200),
       barrierDismissible: barrierDismissible,
       barrierLabel: barrierLabel,
+      routeSettings: routeSettings,
+      navigatorKey: navigatorKey,
+      transitionBuilder: transitionBuilder,
       pageBuilder: (BuildContext buildContext, _, __) {
         final child = Builder(
           key: useSafeArea ? null : Key('dialog_view'),
@@ -245,6 +253,7 @@ class DialogService {
     String confirmationTitle = 'Ok',
     Color? confirmationTitleColor,
     bool barrierDismissible = false,
+    RouteSettings? routeSettings,
 
     /// Indicates which [DialogPlatform] to show.
     ///
@@ -252,15 +261,15 @@ class DialogService {
     DialogPlatform? dialogPlatform,
   }) =>
       showDialog(
-        title: title,
-        description: description,
-        buttonTitle: confirmationTitle,
-        buttonTitleColor: confirmationTitleColor,
-        cancelTitle: cancelTitle,
-        cancelTitleColor: cancelTitleColor,
-        dialogPlatform: dialogPlatform,
-        barrierDismissible: barrierDismissible,
-      );
+          title: title,
+          description: description,
+          buttonTitle: confirmationTitle,
+          buttonTitleColor: confirmationTitleColor,
+          cancelTitle: cancelTitle,
+          cancelTitleColor: cancelTitleColor,
+          dialogPlatform: dialogPlatform,
+          barrierDismissible: barrierDismissible,
+          routeSettings: routeSettings);
 
   /// Completes the dialog and passes the [response] to the caller
   void completeDialog(DialogResponse response) {


### PR DESCRIPTION
Description:
It would be beneficial if showDialog, showCustomDialog, and related methods provided additional parameters to enhance customization options:

	•	RouteSettings? routeSettings
	•	GlobalKey<NavigatorState>? navigatorKey
	•	RouteTransitionsBuilder? transitionBuilder,


Use Case:
These parameters would allow:

	•	Custom Routing: routeSettings would enable setting a name and arguments for the dialog’s route, which can assist in analytics and tracking.
	•	Navigator Targeting: navigatorKey would provide flexibility to show dialogs in specific navigator instances, which is helpful in applications with multiple navigators or nested navigation.
	•	Custom Transitions: transitionBuilder would allow for custom transition animations when displaying dialogs. This is useful for creating a unique user experience or matching the dialog transitions with the app’s design style.

**Example image for routing log:**
The first line is without routeSettings parameter. The second line is with routeSettings parameter.
![Screenshot 2024-11-05 at 20 28 11](https://github.com/user-attachments/assets/eb5d5a86-a948-4b5e-9298-f6563e64e39c)

