### PR TITLE
Rename Transition enum to TransitionStyle to avoid conflict with bloc package

### DIFF
--- a/example/lib/ui/views/first_screen.dart
+++ b/example/lib/ui/views/first_screen.dart
@@ -35,7 +35,7 @@ class FirstScreen extends StatelessWidget {
               child: Text("Use Fade Transition"),
               onPressed: () async {
                 await _navigationService.navigateWithTransition(SecondScreen(),
-                    transitionStyle: Transition.upToDown);
+                    transitionStyle: TransitionStyle.upToDown);
               },
             ),
             OutlinedButton(
@@ -43,7 +43,7 @@ class FirstScreen extends StatelessWidget {
               onPressed: () async {
                 await _navigationService.navigateWithTransition(
                   SecondScreen(),
-                  transitionStyle: Transition.rightToLeft,
+                  transitionStyle: TransitionStyle.rightToLeft,
                 );
               },
             ),
@@ -59,7 +59,7 @@ class FirstScreen extends StatelessWidget {
               child: Text("Use Cupertino Transition"),
               onPressed: () async {
                 await _navigationService.navigateToView(SecondScreen(),
-                    transitionStyle: Transition.zoom);
+                    transitionStyle: TransitionStyle.zoom);
               },
             ),
             OutlinedButton(

--- a/lib/src/navigation/navigation_service.dart
+++ b/lib/src/navigation/navigation_service.dart
@@ -20,16 +20,18 @@ class NavigationTransition {
 ///
 /// Uses the Get library for all navigation requirements
 class NavigationService {
-  Map<String, Transition> _transitions = {
-    Transition.fade.name: Transition.fade,
-    Transition.rightToLeft.name: Transition.rightToLeft,
-    Transition.leftToRight.name: Transition.leftToRight,
-    Transition.upToDown.name: Transition.upToDown,
-    Transition.downToUp.name: Transition.downToUp,
-    Transition.zoom.name: Transition.zoom,
-    Transition.rightToLeftWithFade.name: Transition.rightToLeftWithFade,
-    Transition.leftToRightWithFade.name: Transition.leftToRightWithFade,
-    Transition.noTransition.name: Transition.noTransition,
+  Map<String, TransitionStyle> _transitions = {
+    TransitionStyle.fade.name: TransitionStyle.fade,
+    TransitionStyle.rightToLeft.name: TransitionStyle.rightToLeft,
+    TransitionStyle.leftToRight.name: TransitionStyle.leftToRight,
+    TransitionStyle.upToDown.name: TransitionStyle.upToDown,
+    TransitionStyle.downToUp.name: TransitionStyle.downToUp,
+    TransitionStyle.zoom.name: TransitionStyle.zoom,
+    TransitionStyle.rightToLeftWithFade.name:
+        TransitionStyle.rightToLeftWithFade,
+    TransitionStyle.leftToRightWithFade.name:
+        TransitionStyle.leftToRightWithFade,
+    TransitionStyle.noTransition.name: TransitionStyle.noTransition,
   };
 
   @Deprecated(
@@ -58,7 +60,7 @@ class NavigationService {
     bool? defaultOpaqueRoute,
     Duration? defaultDurationTransition,
     bool? defaultGlobalState,
-    Transition? defaultTransitionStyle,
+    TransitionStyle? defaultTransitionStyle,
     @Deprecated(
         'Prefer to use the defaultTransitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
     String? defaultTransition,
@@ -102,8 +104,8 @@ class NavigationService {
     bool preventDuplicates = true,
     @Deprecated(
         'Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-    Transition? transitionClass,
-    Transition? transitionStyle,
+    TransitionStyle? transitionClass,
+    TransitionStyle? transitionStyle,
     String? routeName,
   }) {
     return G.Get.to<T?>(
@@ -151,8 +153,8 @@ class NavigationService {
     bool preventDuplicates = true,
     @Deprecated(
         'Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-    Transition? transitionClass,
-    Transition? transitionStyle,
+    TransitionStyle? transitionClass,
+    TransitionStyle? transitionStyle,
     String? routeName,
   }) {
     return G.Get.off<T?>(
@@ -241,8 +243,8 @@ class NavigationService {
     bool preventDuplicates = true,
     @Deprecated(
         'Prefer to use the transitionStyle instead of using this property. This will be removed in the next major version update for stacked.')
-    Transition? transition,
-    Transition? transitionStyle,
+    TransitionStyle? transition,
+    TransitionStyle? transitionStyle,
   }) {
     return G.Get.to<T?>(
       () => view,

--- a/lib/src/navigation/route_transition.dart
+++ b/lib/src/navigation/route_transition.dart
@@ -1,6 +1,6 @@
 import 'package:get/get.dart' as G;
 
-enum Transition {
+enum TransitionStyle {
   fade,
   rightToLeft,
   leftToRight,
@@ -12,26 +12,26 @@ enum Transition {
   zoom,
 }
 
-extension ToGetTransition on Transition {
+extension ToGetTransition on TransitionStyle {
   G.Transition get toGet {
     switch (this) {
-      case Transition.fade:
+      case TransitionStyle.fade:
         return G.Transition.fade;
-      case Transition.leftToRight:
+      case TransitionStyle.leftToRight:
         return G.Transition.leftToRight;
-      case Transition.rightToLeft:
+      case TransitionStyle.rightToLeft:
         return G.Transition.rightToLeft;
-      case Transition.upToDown:
+      case TransitionStyle.upToDown:
         return G.Transition.upToDown;
-      case Transition.downToUp:
+      case TransitionStyle.downToUp:
         return G.Transition.downToUp;
-      case Transition.zoom:
+      case TransitionStyle.zoom:
         return G.Transition.zoom;
-      case Transition.leftToRightWithFade:
+      case TransitionStyle.leftToRightWithFade:
         return G.Transition.leftToRightWithFade;
-      case Transition.rightToLeftWithFade:
+      case TransitionStyle.rightToLeftWithFade:
         return G.Transition.rightToLeftWithFade;
-      case Transition.noTransition:
+      case TransitionStyle.noTransition:
         return G.Transition.noTransition;
 
       default:


### PR DESCRIPTION
I was using the stacked_services package alongside flutter_bloc and bloc. When I tried to add a transition to the navigation, I had to use an import alias to avoid conflicts and reference the specific one I needed.